### PR TITLE
Vertical stencil implemented

### DIFF
--- a/qbuild.sh
+++ b/qbuild.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1090
+source "$SCRIPT_DIR/scripts/common.sh"
+
+BUILD_TYPE="Release"
+JOBS="$(nproc)"
+
+is_integer() {
+  [[ "$1" =~ ^[0-9]+$ ]]
+}
+
+case $# in
+  0)
+    ;;
+  1)
+    if is_integer "$1"; then
+      JOBS="$1"
+    else
+      BUILD_TYPE="$1"
+    fi
+    ;;
+  2)
+    if is_integer "$1" && ! is_integer "$2"; then
+      JOBS="$1"
+      BUILD_TYPE="$2"
+    elif ! is_integer "$1" && is_integer "$2"; then
+      BUILD_TYPE="$1"
+      JOBS="$2"
+    else
+      log ERROR "With 2 arguments pass exactly one number (JOBS) and one string (BUILD_TYPE)." >&2
+      log ERROR "Usage: $0 [BUILD_TYPE|JOBS] [BUILD_TYPE|JOBS]" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    log ERROR "Usage: $0 [BUILD_TYPE|JOBS] [BUILD_TYPE|JOBS]" >&2
+    exit 1
+    ;;
+esac
+
+log INFO "Starting full build (tt-metal + tt-wavelet) with -j${JOBS}"
+export_tt_env
+apply_cmake_fixes
+configure_project "$BUILD_TYPE"
+cmake --build "$BUILD_DIR" -j"${JOBS}"
+
+log INFO "Installing tt-metal Python bindings into the venv"
+activate_venv
+python -m pip install -e "$TT_METAL_DIR"
+
+log INFO "Build complete. Outputs in $BUILD_DIR"
+log INFO "To keep env vars in this shell: source $SCRIPT_DIR/scripts/set_env.sh"

--- a/tt-wavelet/CMakeLists.txt
+++ b/tt-wavelet/CMakeLists.txt
@@ -1,22 +1,9 @@
 if(BUILD_TT_WAVELET)
-  find_package(Python3 REQUIRED COMPONENTS Interpreter)
   add_compile_definitions(TT_WAVELET_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
-  set(PROJECT_NAME lwt)
-  add_custom_target(
-    tt_wavelet_generate_static_schemes
-    COMMAND
-      ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/scripts/generate_static_schemes.py
-      --json-dir ${CMAKE_SOURCE_DIR}/wavelets
-      --scheme-dir ${CMAKE_CURRENT_SOURCE_DIR}/tt_wavelet/include/schemes/generated
-      --registry ${CMAKE_CURRENT_SOURCE_DIR}/tt_wavelet/include/schemes/generated/registry.hpp
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    COMMENT "Generating static TT-wavelet scheme headers")
   add_executable(
-    ${PROJECT_NAME} main.cpp tt_wavelet/src/pad_split/device.cpp
-        tt_wavelet/src/lifting/device.cpp)
-  add_dependencies(${PROJECT_NAME} tt_wavelet_generate_static_schemes)
-  set_target_properties(${PROJECT_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
-                                                   "${CMAKE_BINARY_DIR}")
+    tt_wavelet_test
+          stencil.cpp
+  )
 
   set(TT_WAVELET_LLK_INCLUDE_CANDIDATES
       ${CMAKE_SOURCE_DIR}/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib
@@ -34,9 +21,9 @@ if(BUILD_TT_WAVELET)
   set(TT_WAVELET_LLK_INCLUDE_DIRS)
 
   set(TT_WAVELET_INCLUDE_DIRS
-      ${CMAKE_SOURCE_DIR}/tt-metal ${CMAKE_SOURCE_DIR}/tt-metal/tt_metal/common
+      ${CMAKE_SOURCE_DIR}/tt-metal
+      ${CMAKE_SOURCE_DIR}/tt-metal/tt_metal/common
       ${CMAKE_SOURCE_DIR}/tt-metal/tt_metal/api/tt-metalium
-      ${CMAKE_SOURCE_DIR}
       ${CMAKE_CURRENT_SOURCE_DIR})
   foreach(LLK_INCLUDE_DIR IN LISTS TT_WAVELET_LLK_INCLUDE_CANDIDATES)
     if(EXISTS "${LLK_INCLUDE_DIR}")
@@ -45,12 +32,10 @@ if(BUILD_TT_WAVELET)
   endforeach()
 
   if(DEFINED METALIUM_INCLUDE_DIRS)
-    target_include_directories(${PROJECT_NAME}
-                               PRIVATE ${METALIUM_INCLUDE_DIRS})
+    target_include_directories(tt_wavelet_test PRIVATE ${METALIUM_INCLUDE_DIRS})
   endif()
-  target_include_directories(${PROJECT_NAME}
+  target_include_directories(tt_wavelet_test
                              PRIVATE ${TT_WAVELET_LLK_INCLUDE_DIRS})
-  target_include_directories(${PROJECT_NAME}
-                             PRIVATE ${TT_WAVELET_INCLUDE_DIRS})
-  target_link_libraries(${PROJECT_NAME} PRIVATE Metalium::Metal)
+  target_include_directories(tt_wavelet_test PRIVATE ${TT_WAVELET_INCLUDE_DIRS})
+  target_link_libraries(tt_wavelet_test PRIVATE Metalium::Metal)
 endif()

--- a/tt-wavelet/kernels/dataflow/stencil_read.cpp
+++ b/tt-wavelet/kernels/dataflow/stencil_read.cpp
@@ -1,0 +1,28 @@
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/tensor/tensor_accessor.h"
+
+void kernel_main() {
+    const uint32_t input_addr = get_arg_val<uint32_t>(0);
+
+    constexpr uint32_t cb_halo = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_input = get_compile_time_arg_val(1);
+
+    constexpr uint32_t t_size_b = get_tile_size(cb_halo);
+
+    constexpr auto input_args = TensorAccessorArgs<2>();
+    const auto input = TensorAccessor(input_args, input_addr, t_size_b);
+
+    cb_reserve_back(cb_halo, 1);
+    // fisrt tile halo from dram to cb halo 0
+    noc_async_read_tile(0, input, get_write_ptr(cb_halo));
+    noc_async_read_barrier();
+    cb_push_back(cb_halo, 1);
+
+    // second tile input from dram to cb input 1
+    cb_reserve_back(cb_input, 1);
+    noc_async_read_tile(1, input, get_write_ptr(cb_input));
+    noc_async_read_barrier();
+    cb_push_back(cb_input, 1);
+}

--- a/tt-wavelet/kernels/dataflow/stencil_write.cpp
+++ b/tt-wavelet/kernels/dataflow/stencil_write.cpp
@@ -1,0 +1,27 @@
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/tensor/tensor_accessor.h"
+
+void kernel_main() {
+    const uint32_t output_addr = get_arg_val<uint32_t>(0);
+    const uint32_t cb_output = get_compile_time_arg_val(0);
+    constexpr uint32_t t_size_b = get_tile_size(cb_output);
+    const auto output_args = TensorAccessorArgs<1>();
+    const auto output = TensorAccessor(output_args, output_addr, t_size_b);
+
+    cb_wait_front(cb_output, 1);
+    const uint32_t l1_read_addr = get_read_ptr(cb_output);
+    noc_async_write_tile(0, output, l1_read_addr);
+    noc_async_write_barrier();
+    cb_pop_front(cb_output, 1);
+
+    //     // Temporary debug path: dump two tiles from cb_output.
+    // for (uint32_t tile_id = 0; tile_id < 2; ++tile_id) {
+    //     cb_wait_front(cb_output, 1);
+    //     const uint32_t l1_read_addr = get_read_ptr(cb_output);
+    //     noc_async_write_tile(tile_id, output, l1_read_addr);
+    //     noc_async_write_barrier();
+    //     cb_pop_front(cb_output, 1);
+    // }
+}

--- a/tt-wavelet/kernels/dataflow/stencil_write.cpp
+++ b/tt-wavelet/kernels/dataflow/stencil_write.cpp
@@ -5,7 +5,7 @@
 
 void kernel_main() {
     const uint32_t output_addr = get_arg_val<uint32_t>(0);
-    const uint32_t cb_output = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_output = get_compile_time_arg_val(0);
     constexpr uint32_t t_size_b = get_tile_size(cb_output);
     const auto output_args = TensorAccessorArgs<1>();
     const auto output = TensorAccessor(output_args, output_addr, t_size_b);

--- a/tt-wavelet/kernels/sfpi/vertical_stencil_sfpi.h
+++ b/tt-wavelet/kernels/sfpi/vertical_stencil_sfpi.h
@@ -72,9 +72,12 @@ inline void _vertical_stencil_rotate_() {
 //   f1: second 4x8 block (next 4 rows)
 //   f2: third 4x8 block (next 4 rows)
 //   f3: fourth 4x8 block (next 4 rows)
-//   g1: first 4x8 block output
-//   g2: second 4x8 block output
-//   g3: third 4x8 block output
+//   g0: first 4x8 block output
+//   g1: second 4x8 block output
+//   g2: third 4x8 block output
+//   base0: first 4x8 block base
+//   base1: second 4x8 block base
+//   base2: third 4x8 block base
 template <uint8_t K>
 inline void _vertical_stencil_block(
     const uint32_t h_packed[K],
@@ -84,7 +87,10 @@ inline void _vertical_stencil_block(
     const uint32_t dst_f3,
     const uint32_t dst_g0,
     const uint32_t dst_g1,
-    const uint32_t dst_g2
+    const uint32_t dst_g2,
+    const uint32_t dst_base0 = 512,
+    const uint32_t dst_base1 = 512,
+    const uint32_t dst_base2 = 512
 ) {
     // Register allocations
     const auto& f_0 = p_sfpu::LREG0;
@@ -102,17 +108,25 @@ inline void _vertical_stencil_block(
     TT_SFPLOAD(f_2, sfpi::SFPLOAD_MOD0_FMT_FP32, ADDR_MOD_3, dst_f2);      // f_2
     TT_SFPLOAD(f_3, sfpi::SFPLOAD_MOD0_FMT_FP32, ADDR_MOD_3, dst_f3);      // f_3
 
-    // Zero the output accumulators
-    if constexpr (K < 6) {
-        TTI_SFPMOV(0, p_sfpu::LCONST_0, g_0, 0); // g_0 = 0
-        TTI_SFPMOV(0, p_sfpu::LCONST_0, g_1, 0); // g_1 = 0
-        TTI_SFPMOV(0, p_sfpu::LCONST_0, g_2, 0); // g_2 = 0
-    } else if constexpr (K < 10) {
-        TTI_SFPMOV(0, p_sfpu::LCONST_0, g_0, 0); // g_0 = 0
-        TTI_SFPMOV(0, p_sfpu::LCONST_0, g_1, 0); // g_1 = 0
+    // Load base from Dst
+    if (dst_base0 < 512) {
+        TT_SFPLOAD(g_0, sfpi::SFPLOAD_MOD0_FMT_FP32, ADDR_MOD_3, dst_base0); // g_0
     } else {
         TTI_SFPMOV(0, p_sfpu::LCONST_0, g_0, 0); // g_0 = 0
     }
+
+    if(K < 10 && (dst_base1 < 512)) {
+        TT_SFPLOAD(g_1, sfpi::SFPLOAD_MOD0_FMT_FP32, ADDR_MOD_3, dst_base1); // g_1
+    } else if (K < 10) {
+        TTI_SFPMOV(0, p_sfpu::LCONST_0, g_1, 0); // g_1 = 0
+    }
+
+    if(K < 6 && (dst_base2 < 512)) {
+        TT_SFPLOAD(g_2, sfpi::SFPLOAD_MOD0_FMT_FP32, ADDR_MOD_3, dst_base2); // g_2
+    } else if (K < 6) {
+        TTI_SFPMOV(0, p_sfpu::LCONST_0, g_2, 0); // g_2 = 0
+    }
+
 
 #pragma unroll 17
     for (uint8_t j = 0; j < K; j++) {
@@ -156,7 +170,7 @@ inline void _vertical_stencil_block(
 //   output: tile index in dst register for output (can be same as either input)
 template <uint8_t K>
 inline void _vertical_stencil(
-    const uint32_t h_packed[K], const uint32_t input1, const uint32_t input2, const uint32_t output) {
+    const uint32_t h_packed[K], const uint32_t input1, const uint32_t input2, const uint32_t output, const uint32_t base = 8)
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(0);
     // We use addr mod 3, so base=0
     ckernel::math::clear_addr_mod_base();
@@ -179,7 +193,10 @@ inline void _vertical_stencil(
                 _get_block(input1, input2, row + 12, col),
                 _get_block(output, 8, row, col),
                 _get_block(output, 8, row + 4, col),
-                _get_block(output, 8, row + 8, col)
+                _get_block(output, 8, row + 8, col),
+                _get_dst_base(base, 8, row, col),
+                _get_dst_base(base, 8, row + 4, col),
+                _get_dst_base(base, 8, row + 8, col)
             );
         }
     }
@@ -194,6 +211,6 @@ inline void vstencil_init() { MATH((ckernel::sfpu::_vertical_stencil_init())); }
 
 template <uint8_t K>
 inline void vstencil_tile(
-    std::array<uint32_t, K> h_packed, const uint32_t input1, const uint32_t input2, const uint32_t output) {
-    MATH((ckernel::sfpu::_vertical_stencil<K>(h_packed.data(), input1, input2, output)));
+    std::array<uint32_t, K> h_packed, const uint32_t input1, const uint32_t input2, const uint32_t output, const uint32_t base = 8) {
+    MATH((ckernel::sfpu::_vertical_stencil<K>(h_packed.data(), input1, input2, output, base)));
 }

--- a/tt-wavelet/kernels/sfpi/vertical_stencil_sfpi.h
+++ b/tt-wavelet/kernels/sfpi/vertical_stencil_sfpi.h
@@ -163,8 +163,8 @@ inline void _vertical_stencil(
     TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH);
 
     constexpr uint32_t ROW_STRIDE =
-        (K >= 14) ? 4 :
-        (K >= 10) ? 8 :
+        (K >= 10) ? 4 :
+        (K >= 6) ? 8 :
                     12;
 
 #pragma unroll 8

--- a/tt-wavelet/kernels/sfpi/vertical_stencil_sfpi.h
+++ b/tt-wavelet/kernels/sfpi/vertical_stencil_sfpi.h
@@ -22,13 +22,29 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-inline uint32_t _get_dst_base(const uint32_t tile_index, const uint32_t face_index) {
+inline uint32_t _get_dst_base(const uint32_t tile_index, const uint32_t face_index, const uint32_t row_index, const uint32_t col_index) {
     // addr uint10: XTTTFFRRCX
     // T: tile index (0-7) << 6
     // F: face index (0-3) << 4
     // R: row index (0,4,8,12)
     // C: column index (0 for even cols, 1 for odd cols)*2
-    return (tile_index << 6) + (face_index << 4);
+    return (tile_index << 6) + (face_index << 4) + row_index + (col_index << 1);
+}
+
+inline uint32_t _get_block(const uint32_t tile1, const uint32_t tile2, const uint32_t row_index, const uint32_t col_index) {
+    const uint32_t tile = (row_index < 32) ? tile1 : tile2;
+    const uint32_t col_face = (col_index < 2) ? 0 : 1;
+    const uint32_t row_face = ((row_index % 32) < 16) ? 0 : 1;
+    const uint32_t face = row_face * 2 + col_face;
+    const uint32_t row_offset = row_index % 16;
+    const uint32_t col_offset = col_index % 2;
+
+    return _get_dst_base(
+        tile,
+        face,
+        row_offset,
+        col_offset
+    );
 }
 
 inline void _vertical_stencil_init() {
@@ -65,18 +81,18 @@ inline void _vertical_stencil_block(
     const uint32_t dst_f1,
     const uint32_t dst_f2,
     const uint32_t dst_f3,
+    const uint32_t dst_g0,
     const uint32_t dst_g1,
-    const uint32_t dst_g2,
-    const uint32_t dst_g3
+    const uint32_t dst_g2
 ) {
     // Register allocations
     const auto& f_0 = p_sfpu::LREG0;
     const auto& f_1 = p_sfpu::LREG1;
     const auto& f_2 = p_sfpu::LREG2;
     const auto& f_3 = p_sfpu::LREG3;
-    const auto& g_1 = p_sfpu::LREG4;
-    const auto& g_2 = p_sfpu::LREG5;
-    const auto& g_3 = p_sfpu::LREG6;
+    const auto& g_0 = p_sfpu::LREG4;
+    const auto& g_1 = p_sfpu::LREG5;
+    const auto& g_2 = p_sfpu::LREG6;
     const auto& tmp = p_sfpu::LREG7;
 
     // Load inputs into LRegs, for odd columns offset of 2 is used
@@ -86,32 +102,34 @@ inline void _vertical_stencil_block(
     TT_SFPLOAD(f_3, sfpi::SFPLOAD_MOD0_FMT_FP32, ADDR_MOD_3, dst_f3);      // f_3
 
     // Zero the output accumulators
-    TTI_SFPMOV(0, p_sfpu::LCONST_0, g_1, 0); // g_1 = 0
-    if constexpr (K < 10) {
+    if constexpr (K < 6) {
+        TTI_SFPMOV(0, p_sfpu::LCONST_0, g_0, 0); // g_0 = 0
+        TTI_SFPMOV(0, p_sfpu::LCONST_0, g_1, 0); // g_1 = 0
         TTI_SFPMOV(0, p_sfpu::LCONST_0, g_2, 0); // g_2 = 0
-    }
-
-    if constexpr (K < 14) {
-        TTI_SFPMOV(0, p_sfpu::LCONST_0, g_3, 0); // g_3 = 0
+    } else if constexpr (K < 10) {
+        TTI_SFPMOV(0, p_sfpu::LCONST_0, g_0, 0); // g_0 = 0
+        TTI_SFPMOV(0, p_sfpu::LCONST_0, g_1, 0); // g_1 = 0
+    } else {
+        TTI_SFPMOV(0, p_sfpu::LCONST_0, g_0, 0); // g_0 = 0
     }
 
 #pragma unroll 17
     for (uint8_t j = 0; j < K; j++) {
-        TT_SFPLOADI(tmp, sfpi::SFPLOADI_MOD0_UPPER, (h_packed[(k-1) - j]) >> 16);
-        TT_SFPLOADI(tmp, sfpi::SFPLOADI_MOD0_LOWER, (h_packed[(k-1) - j]) & 0xFFFF);
+        TT_SFPLOADI(tmp, sfpi::SFPLOADI_MOD0_UPPER, (h_packed[(K-1) - j]) >> 16);
+        TT_SFPLOADI(tmp, sfpi::SFPLOADI_MOD0_LOWER, (h_packed[(K-1) - j]) & 0xFFFF);
 
         if constexpr (K < 6) {
-            // g_0 += h[(k-1)-j] * f_3
-            TTI_SFPMAD(f_3, tmp, g_3, g_3, 0);
-        } else if constexpr (K < 10) {
-            // g_0 += h[(k-1)-j] * f_2
-            TTI_SFPMAD(f_2, tmp, g_2, g_2, 0);
-            // g_1 += h[(k-1)-j] * f_3
-            TTI_SFPMAD(f_3, tmp, g_3, g_3, 0);
-        } else {
+            TTI_SFPMAD(f_0, tmp, g_0, g_0, 0);
             TTI_SFPMAD(f_1, tmp, g_1, g_1, 0);
             TTI_SFPMAD(f_2, tmp, g_2, g_2, 0);
-            TTI_SFPMAD(f_3, tmp, g_3, g_3, 0);
+        } else if constexpr (K < 10) {
+            // g_0 += h[(k-1)-j] * f_0
+            TTI_SFPMAD(f_0, tmp, g_0, g_0, 0);
+            // g_1 += h[(k-1)-j] * f_1
+            TTI_SFPMAD(f_1, tmp, g_1, g_1, 0);
+        } else {
+            // g_0 += h[(k-1)-j] * f_0
+            TTI_SFPMAD(f_0, tmp, g_0, g_0, 0);
         }
 
         if (j != K - 1) { // No need to rotate on the last iteration
@@ -120,28 +138,12 @@ inline void _vertical_stencil_block(
     }
 
     // Store results back to Dst
-    TT_SFPSTORE(g_1, sfpi::SFPSTORE_MOD0_FMT_FP32, ADDR_MOD_3, dst_g1); // g_1
-    if constexpr (K < 10) {
+    TT_SFPSTORE(g_0, sfpi::SFPSTORE_MOD0_FMT_FP32, ADDR_MOD_3, dst_g0); // g_0
+    if(K < 10 && (dst_g1 < 512)) {
+        TT_SFPSTORE(g_1, sfpi::SFPSTORE_MOD0_FMT_FP32, ADDR_MOD_3, dst_g1); // g_1
+    }
+    if(K < 6 && (dst_g2 < 512)) {
         TT_SFPSTORE(g_2, sfpi::SFPSTORE_MOD0_FMT_FP32, ADDR_MOD_3, dst_g2); // g_2
-    }
-    if constexpr (K < 14) {
-        TT_SFPSTORE(g_3, sfpi::SFPSTORE_MOD0_FMT_FP32, ADDR_MOD_3, dst_g3); // g_3
-    }
-}
-
-template <uint8_t K, uint32_t Rows>
-inline void _vertical_stencil(
-    const uint32_t h_packed[K],
-    const uint32_t input1,
-    const uint32_t input2,
-    const uint32_t output
-) {
-    constexpr uint32_t ROWS = std::min(Rows, static_cast<uint32_t>(16));
-    constexpr uint32_t ROW_STRIDE = 4;
-
-#pragma unroll 4
-    for (uint32_t row = 0; row < ROWS; row += ROW_STRIDE) {
-        _horizontal_stencil_block<K>(h_packed, input1 + row, input2 + row, output + row);
     }
 }
 
@@ -150,27 +152,34 @@ inline void _vertical_stencil(
 //   input1: first tile index in dst register
 //   input2: second tile index in dst register
 //   output: tile index in dst register for output (can be same as either input)
-//
-// Template arguments:
-//   Rows: minimum number of Rows of the tile to be processed
-template <uint8_t K, uint32_t Rows>
-inline void _horizontal_stencil(
+template <uint8_t K>
+inline void _vertical_stencil(
     const uint32_t h_packed[K], const uint32_t input1, const uint32_t input2, const uint32_t output) {
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(0);
     // We use addr mod 3, so base=0
     ckernel::math::clear_addr_mod_base();
     TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH);
 
-    _horizontal_stencil_face<K, Rows>(
-        h_packed, _get_dst_base(input1, 0), _get_dst_base(input1, 1), _get_dst_base(output, 0));
-    _horizontal_stencil_face<K, Rows>(
-        h_packed, _get_dst_base(input1, 1), _get_dst_base(input2, 0), _get_dst_base(output, 1));
+    constexpr uint32_t ROW_STRIDE =
+        (K >= 14) ? 4 :
+        (K >= 10) ? 8 :
+                    12;
 
-    if constexpr (Rows > 16) {
-        _horizontal_stencil_face<K, Rows - 16>(
-            h_packed, _get_dst_base(input1, 2), _get_dst_base(input1, 3), _get_dst_base(output, 2));
-        _horizontal_stencil_face<K, Rows - 16>(
-            h_packed, _get_dst_base(input1, 3), _get_dst_base(input2, 2), _get_dst_base(output, 3));
+#pragma unroll 8
+    for (uint32_t row = 0; row < 32; row += ROW_STRIDE) {
+#pragma unroll 4
+        for (uint32_t col = 0; col < 4; col += 1) {
+            _vertical_stencil_block<K>(
+                h_packed,
+                _get_block(input1, input2, row, col),
+                _get_block(input1, input2, row + 4, col),
+                _get_block(input1, input2, row + 8, col),
+                _get_block(input1, input2, row + 12, col),
+                _get_block(output, 8, row, col),
+                _get_block(output, 8, row + 4, col),
+                _get_block(output, 8, row + 8, col)
+            );
+        }
     }
 
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::WAIT_SFPU);
@@ -179,16 +188,10 @@ inline void _horizontal_stencil(
 }  // namespace sfpu
 }  // namespace ckernel
 
-inline void hstencil_init() { MATH((ckernel::sfpu::_horizontal_stencil_init())); }
-
-template <uint8_t K, uint32_t Rows = 32>
-inline void hstencil_tile(
-    std::array<uint32_t, K> h_packed, const uint32_t input1, const uint32_t input2, const uint32_t output) {
-    MATH((ckernel::sfpu::_horizontal_stencil<K, Rows>(h_packed.data(), input1, input2, output)));
-}
+inline void vstencil_init() { MATH((ckernel::sfpu::_vertical_stencil_init())); }
 
 template <uint8_t K>
-inline void hstencil_row(
+inline void vstencil_tile(
     std::array<uint32_t, K> h_packed, const uint32_t input1, const uint32_t input2, const uint32_t output) {
-    hstencil_tile<K, 1>(h_packed, input1, input2, output);
+    MATH((ckernel::sfpu::_vertical_stencil<K>(h_packed.data(), input1, input2, output)));
 }

--- a/tt-wavelet/kernels/sfpi/vertical_stencil_sfpi.h
+++ b/tt-wavelet/kernels/sfpi/vertical_stencil_sfpi.h
@@ -170,7 +170,7 @@ inline void _vertical_stencil_block(
 //   output: tile index in dst register for output (can be same as either input)
 template <uint8_t K>
 inline void _vertical_stencil(
-    const uint32_t h_packed[K], const uint32_t input1, const uint32_t input2, const uint32_t output, const uint32_t base = 8)
+    const uint32_t h_packed[K], const uint32_t input1, const uint32_t input2, const uint32_t output, const uint32_t base = 8) {
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(0);
     // We use addr mod 3, so base=0
     ckernel::math::clear_addr_mod_base();

--- a/tt-wavelet/kernels/sfpi/vertical_stencil_sfpi.h
+++ b/tt-wavelet/kernels/sfpi/vertical_stencil_sfpi.h
@@ -194,9 +194,9 @@ inline void _vertical_stencil(
                 _get_block(output, 8, row, col),
                 _get_block(output, 8, row + 4, col),
                 _get_block(output, 8, row + 8, col),
-                _get_dst_base(base, 8, row, col),
-                _get_dst_base(base, 8, row + 4, col),
-                _get_dst_base(base, 8, row + 8, col)
+                _get_block(base, base, row, col),
+                _get_block(base, base, row + 4, col),
+                _get_block(base, base, row + 8, col)
             );
         }
     }

--- a/tt-wavelet/kernels/sfpi/vertical_stencil_sfpi.h
+++ b/tt-wavelet/kernels/sfpi/vertical_stencil_sfpi.h
@@ -52,6 +52,7 @@ inline void _vertical_stencil_init() {
 
     addr_mod_t addr_mod{.dest = {.incr = 0}};
     addr_mod.set(ADDR_MOD_3);
+    math::reset_counters(p_setrwc::SET_ABD_F);
 
     // Enable all lanes
     TTI_SFPENCC(sfpi::SFPENCC_IMM12_BOTH, 0, 0, sfpi::SFPENCC_MOD1_EI_RI);
@@ -59,10 +60,10 @@ inline void _vertical_stencil_init() {
 
 // _vertical_stencil_rotate_(): 1-element up shift within subvectors of LReg0-LReg3.
 inline void _vertical_stencil_rotate_() {
-    TT_SFPTRANSP();
+    TT_SFPTRANSP(0, 0, 0, 0);
     TT_SFPSHFT2(0, 0, 0, sfpi::SFPSHFT2_MOD1_SUBVEC_CHAINED_COPY4);
     TTI_SFPNOP;
-    TT_SSFPTRANSP();
+    TT_SFPTRANSP(0, 0, 0, 0);
 }
 
 // Arguments:
@@ -132,6 +133,7 @@ inline void _vertical_stencil_block(
             TTI_SFPMAD(f_0, tmp, g_0, g_0, 0);
         }
 
+        TTI_SFPNOP; // Wait for SFPU to finish the multiply-accumulate before rotating
         if (j != K - 1) { // No need to rotate on the last iteration
             _vertical_stencil_rotate_();
         }

--- a/tt-wavelet/kernels/stencil_compute.cpp
+++ b/tt-wavelet/kernels/stencil_compute.cpp
@@ -12,7 +12,6 @@ void kernel_main() {
     constexpr uint32_t cb_input = get_compile_time_arg_val(2);
     constexpr uint32_t cb_output = get_compile_time_arg_val(3);
     constexpr auto h_coeffs_of_step = fill_array_with_next_n_args<uint32_t, 4, K>();
-    (void)h_coeffs_of_step;
     // halo:  [0, 0, ..., 0, 1, 2, 3, ..., 18]
     // input: [19, 20, 21, ..., 32, 0, 0, ..., 0]
     constexpr uint dst_halo = 0;
@@ -33,7 +32,7 @@ void kernel_main() {
     cb_pop_front(cb_input, 1);
 
     vstencil_init();
-    vstencil_tile<K>(h_coeffs_of_step.data(), dst_halo, dst_input, dst_out);
+    vstencil_tile<K>(h_coeffs_of_step, dst_halo, dst_input, dst_out);
 
     tile_regs_commit();
     tile_regs_wait();

--- a/tt-wavelet/kernels/stencil_compute.h
+++ b/tt-wavelet/kernels/stencil_compute.h
@@ -1,0 +1,51 @@
+#include <cstdint>
+
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "sfpi/vertical_stencil_sfpi.h"
+#include "tt_metal/fabric/hw/inc/edm_fabric/compile_time_arg_tmp.hpp"
+
+void kernel_main() {
+    constexpr uint32_t K = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_halo = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_input = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_output = get_compile_time_arg_val(3);
+    constexpr auto h_coeffs_of_step = fill_array_with_next_n_args<uint32_t, 4, K>();
+    (void)h_coeffs_of_step;
+    // halo:  [0, 0, ..., 0, 1, 2, 3, ..., 18]
+    // input: [19, 20, 21, ..., 32, 0, 0, ..., 0]
+    constexpr uint dst_halo = 0;
+    constexpr uint dst_input = 1;
+    constexpr uint dst_out = 2;
+
+    ckernel::init_sfpu(cb_input, cb_output);
+
+    tile_regs_acquire();
+    cb_wait_front(cb_halo, 1);
+    copy_tile_to_dst_init_short(cb_halo);
+    copy_tile(cb_halo, 0, dst_halo);
+    cb_pop_front(cb_halo, 1);
+
+    cb_wait_front(cb_input, 1);
+    copy_tile_to_dst_init_short(cb_input);
+    copy_tile(cb_input, 0, dst_input);
+    cb_pop_front(cb_input, 1);
+
+    vstencil_init();
+    vstencil_tile<K>(h_coeffs_of_step.data(), dst_halo, dst_input, dst_out);
+
+    tile_regs_commit();
+    tile_regs_wait();
+
+    cb_reserve_back(cb_output, 1);
+    pack_tile(dst_out, cb_output);
+    cb_push_back(cb_output, 1);
+
+    // Temporary debug expose the copied halo input tiles  to the writer
+    // cb_reserve_back(cb_output, 2);
+    // pack_tile(dst_halo, cb_output);
+    // pack_tile(dst_input, cb_output);
+    // cb_push_back(cb_output, 2);
+    tile_regs_release();
+}

--- a/tt-wavelet/stencil.cpp
+++ b/tt-wavelet/stencil.cpp
@@ -1,0 +1,217 @@
+#include <bit>
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "tt-metalium/distributed.hpp"
+#include "tt-metalium/host_api.hpp"
+#include "tt-metalium/mesh_buffer.hpp"
+#include "tt-metalium/mesh_device.hpp"
+#include "tt-metalium/tensor_accessor_args.hpp"
+#include "tt-metalium/tilize_utils.hpp"
+#include "tt_wavelet/include/pad_split.hpp"
+#include "tt_wavelet/include/pad_split_device.hpp"
+
+inline tt::tt_metal::CBHandle create_circular_buffer(
+    tt::tt_metal::Program& program,
+    const tt::tt_metal::CoreCoord& core,
+    tt::CBIndex cb_index,
+    const uint32_t num_tiles_in_cb,
+    const uint32_t tile_size_bytes,
+    tt::DataFormat data_format = tt::DataFormat::Float32) {
+    const tt::tt_metal::CircularBufferConfig cb_config =
+        tt::tt_metal::CircularBufferConfig(num_tiles_in_cb * tile_size_bytes, {{cb_index, data_format}})
+            .set_page_size(cb_index, tile_size_bytes);
+
+    return tt::tt_metal::CreateCircularBuffer(program, core, cb_config);
+}
+
+template <typename T>
+void print_array(const std::vector<T>& arr) {
+    std::cout << "[";
+    for (size_t i = 0; i < arr.size(); ++i) {
+        std::cout << arr[i] << ", ";
+    }
+    std::cout << "]" << std::endl;
+}
+
+
+void push_step_coeffs_to_compile_args(std::vector<uint32_t>& args, std::vector<float>& coeffs) {
+    for (size_t i{0}; i < coeffs.size(); ++i) {
+        args.push_back(std::bit_cast<uint32_t>(coeffs[i]));
+    }
+}
+
+int main() {
+    constexpr uint32_t num_tiles_input{2};
+    constexpr uint32_t num_tiles_output{1};
+    constexpr uint32_t elems_per_tile{tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH};
+    constexpr tt::DataFormat cb_data_format = tt::DataFormat::Float32;
+    const uint32_t size_tile_b = tt::tile_size(cb_data_format);
+    constexpr int device_id{0};
+    std::string reader{"tt-wavelet/kernels/dataflow/stencil_read.cpp"};
+    std::string writer{"tt-wavelet/kernels/dataflow/stencil_write.cpp"};
+    std::string compute{"tt-wavelet/kernels/stencil_compute.cpp"};
+    auto mesh_device = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
+
+    tt::tt_metal::distributed::MeshCommandQueue& command_queue = mesh_device->mesh_command_queue();
+    auto program = tt::tt_metal::CreateProgram();
+
+    constexpr tt::tt_metal::CoreCoord core{0, 0};
+
+    tt::tt_metal::distributed::DeviceLocalBufferConfig buffer_config{
+        .page_size = size_tile_b, .buffer_type = tt::tt_metal::BufferType::DRAM};
+
+    tt::tt_metal::distributed::ReplicatedBufferConfig input_dram_config{
+        .size = static_cast<uint64_t>(size_tile_b * num_tiles_input)};
+    tt::tt_metal::distributed::ReplicatedBufferConfig output_dram_config{
+        .size = static_cast<uint64_t>(size_tile_b * num_tiles_output)};
+
+    auto input_dram_buffer =
+        tt::tt_metal::distributed::MeshBuffer::create(input_dram_config, buffer_config, mesh_device.get());
+    auto output_dram_buffer =
+        tt::tt_metal::distributed::MeshBuffer::create(output_dram_config, buffer_config, mesh_device.get());
+
+    std::vector<float> halo(32, 0.0f);
+    std::vector<float> input(32, 0.0f);
+    std::vector<float> coeffs = {1.0f, 1.0f, 1.0f};
+    const uint8_t k = coeffs.size();
+    const uint8_t halo_idx = halo_pad(k);
+
+    size_t sig = 1;
+    const size_t halo_signal_count = halo.size() - halo_idx;
+    for (size_t j = 0; j < halo_signal_count; ++j) {
+        halo[halo_idx + j] = static_cast<float>(sig++);
+    }
+
+    const size_t input_signal_count = std::min(input.size(), static_cast<size_t>(halo_idx));
+    for (size_t j = 0; j < input_signal_count; ++j) {
+        input[j] = static_cast<float>(sig++);
+    }
+
+    std::cout << "Halo:";
+    print_array(halo);
+    std::cout << "\n";
+    std::cout << "Input:";
+    print_array(input);
+    std::cout << "\n";
+
+    std::vector<float> halo_tile(elems_per_tile, 0.0f);
+    std::vector<float> input_tile(elems_per_tile, 0.0f);
+    std::copy(halo.begin(), halo.end(), halo_tile.begin());
+    std::copy(input.begin(), input.end(), input_tile.begin());
+
+    const std::vector<uint32_t> tile_shape = {1, 1, tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH};
+
+    // User-requested debug layout: keep first-row-contiguous row-major tile payload.
+    // This bypasses host tilize so flattened tile content matches the custom 32x32 printout.
+    auto tiled_halo = halo_tile;
+    auto tiled_input = input_tile;
+
+    std::vector<float> combined((tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH) * 2);
+    std::cout << "Tiled Halo:" << std::endl;
+    print_array(tiled_halo);
+    std::cout << "Tiled Input:" << std::endl;
+    print_array(tiled_input);
+
+    std::copy(tiled_halo.begin(), tiled_halo.end(), combined.begin());
+    std::copy(
+        tiled_input.begin(),
+        tiled_input.end(),
+        combined.begin() + tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH);
+    std::cout << "Combined Tiles (halo followed by input):" << std::endl;
+    print_array(combined);
+    tt::tt_metal::distributed::EnqueueWriteMeshBuffer(command_queue, input_dram_buffer, combined, false);
+
+    constexpr tt::CBIndex halo_cb = tt::CBIndex::c_0;
+    constexpr tt::CBIndex input_cb = tt::CBIndex::c_1;
+    constexpr tt::CBIndex output_cb = tt::CBIndex::c_16;
+
+    create_circular_buffer(program, core, halo_cb, 1, size_tile_b, cb_data_format);
+    create_circular_buffer(program, core, input_cb, 1, size_tile_b, cb_data_format);
+    create_circular_buffer(program, core, output_cb, 1, size_tile_b, cb_data_format);
+
+    std::vector<uint32_t> reader_compile_args;
+    std::vector<uint32_t> writer_compile_args;
+    reader_compile_args.push_back(static_cast<uint32_t>(halo_cb));
+    reader_compile_args.push_back(static_cast<uint32_t>(input_cb));
+    writer_compile_args.push_back(static_cast<uint32_t>(output_cb));
+    std::vector<uint32_t> compute_compile_args;
+    compute_compile_args.push_back(static_cast<uint32_t>(k));
+    compute_compile_args.push_back(static_cast<uint32_t>(halo_cb));
+    compute_compile_args.push_back(static_cast<uint32_t>(input_cb));
+    compute_compile_args.push_back(static_cast<uint32_t>(output_cb));
+
+    push_step_coeffs_to_compile_args(compute_compile_args, coeffs);
+
+    tt::tt_metal::TensorAccessorArgs(input_dram_buffer->get_backing_buffer()).append_to(reader_compile_args);
+    tt::tt_metal::TensorAccessorArgs(output_dram_buffer->get_backing_buffer()).append_to(writer_compile_args);
+    auto reader_ker = tt::tt_metal::CreateKernel(
+        program,
+        reader,
+        core,
+        tt::tt_metal::DataMovementConfig{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt::tt_metal::RISCV_0_default,
+            .compile_args = reader_compile_args,
+        });
+
+    auto wtiter_ker = tt::tt_metal::CreateKernel(
+        program,
+        writer,
+        core,
+        tt::tt_metal::DataMovementConfig{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = tt::tt_metal::RISCV_1_default,
+            .compile_args = writer_compile_args,
+        });
+
+    auto compute_ker = tt::tt_metal::CreateKernel(
+        program,
+        compute,
+        core,
+        tt::tt_metal::ComputeConfig{
+            .math_fidelity = MathFidelity::HiFi4, .fp32_dest_acc_en = true, .compile_args = compute_compile_args});
+
+    tt::tt_metal::SetRuntimeArgs(program, reader_ker, core, {static_cast<uint32_t>(input_dram_buffer->address())});
+
+    tt::tt_metal::SetRuntimeArgs(program, wtiter_ker, core, {static_cast<uint32_t>(output_dram_buffer->address())});
+    tt::tt_metal::distributed::MeshWorkload workload;
+    tt::tt_metal::distributed::MeshCoordinateRange device_range =
+        tt::tt_metal::distributed::MeshCoordinateRange(mesh_device->shape());
+    workload.add_program(device_range, std::move(program));
+    tt::tt_metal::distributed::EnqueueMeshWorkload(command_queue, workload, false);
+    tt::tt_metal::distributed::Finish(command_queue);
+
+    std::vector<float> result_of_stencil;
+    tt::tt_metal::distributed::EnqueueReadMeshBuffer(command_queue, result_of_stencil, output_dram_buffer);
+    std::cout << "Result of stencil computation:" << std::endl;
+    print_array(result_of_stencil);
+
+    //     std::vector<float> debug_tiles;
+    // tt::tt_metal::distributed::EnqueueReadMeshBuffer(command_queue, debug_tiles, output_dram_buffer);
+
+    // std::vector<float> result_of_halo(debug_tiles.begin(), debug_tiles.begin() + elems_per_tile);
+    // std::vector<float> result_of_input(debug_tiles.begin() + elems_per_tile, debug_tiles.end());
+
+    // print_array(result_of_halo);
+    // print_array(result_of_input);
+
+    // auto result_row_halo = convert_layout(
+    //     tt::stl::make_const_span(result_of_halo),
+    //     tile_shape,
+    //     TensorLayoutType::TILED_NFACES,
+    //     TensorLayoutType::LIN_ROW_MAJOR);
+
+    // print_prefix(result_row_halo, 64, "row-major prefix:");
+
+    // auto result_row_input = convert_layout(
+    //     tt::stl::make_const_span(result_of_input),
+    //     tile_shape,
+    //     TensorLayoutType::TILED_NFACES,
+    //     TensorLayoutType::LIN_ROW_MAJOR);
+
+    // print_prefix(result_row_input, 64, "row-major prefix:");
+}

--- a/tt-wavelet/stencil.cpp
+++ b/tt-wavelet/stencil.cpp
@@ -1,8 +1,13 @@
 #include <bit>
 #include <cassert>
+#include <fstream>
 #include <cmath>
+#include <iomanip>
 #include <iostream>
+#include <limits>
+#include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "tt-metalium/distributed.hpp"
@@ -59,152 +64,263 @@ void push_step_coeffs_to_compile_args(std::vector<uint32_t>& args, std::vector<f
     }
 }
 
-int main() {
-    constexpr uint32_t num_tiles_input{2};
-    constexpr uint32_t num_tiles_output{1};
-    constexpr uint32_t elems_per_tile{tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH};
-    constexpr tt::DataFormat cb_data_format = tt::DataFormat::Float32;
-    const uint32_t size_tile_b = tt::tile_size(cb_data_format);
-    constexpr int device_id{0};
-    std::string reader{"tt-wavelet/kernels/dataflow/stencil_read.cpp"};
-    std::string writer{"tt-wavelet/kernels/dataflow/stencil_write.cpp"};
-    std::string compute{"tt-wavelet/kernels/stencil_compute.cpp"};
-    auto mesh_device = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
+std::vector<float> read_floats_from_file(const std::string& path) {
+    std::ifstream input(path);
+    if (!input.is_open()) {
+        throw std::runtime_error("Failed to open file: " + path);
+    }
 
-    tt::tt_metal::distributed::MeshCommandQueue& command_queue = mesh_device->mesh_command_queue();
-    auto program = tt::tt_metal::CreateProgram();
+    std::vector<float> values;
+    float value = 0.0f;
+    while (input >> value) {
+        values.push_back(value);
+    }
 
-    constexpr tt::tt_metal::CoreCoord core{0, 0};
+    if (!input.eof() && input.fail()) {
+        throw std::runtime_error("Failed while reading floating-point values from: " + path);
+    }
 
-    tt::tt_metal::distributed::DeviceLocalBufferConfig buffer_config{
-        .page_size = size_tile_b, .buffer_type = tt::tt_metal::BufferType::DRAM};
+    return values;
+}
 
-    tt::tt_metal::distributed::ReplicatedBufferConfig input_dram_config{
-        .size = static_cast<uint64_t>(size_tile_b * num_tiles_input)};
-    tt::tt_metal::distributed::ReplicatedBufferConfig output_dram_config{
-        .size = static_cast<uint64_t>(size_tile_b * num_tiles_output)};
+struct KernelSpec {
+    uint8_t k;
+    std::vector<float> coeffs;
+};
 
-    auto input_dram_buffer =
-        tt::tt_metal::distributed::MeshBuffer::create(input_dram_config, buffer_config, mesh_device.get());
-    auto output_dram_buffer =
-        tt::tt_metal::distributed::MeshBuffer::create(output_dram_config, buffer_config, mesh_device.get());
+KernelSpec read_kernel_from_file(const std::string& path) {
+    std::ifstream input(path);
+    if (!input.is_open()) {
+        throw std::runtime_error("Failed to open kernel file: " + path);
+    }
 
-    std::vector<float> halo(32 * 32, 1.0f);
-    std::vector<float> input(32 * 32, 2.0f);
-    std::vector<float> coeffs = {1.0f, 1.0f, 1.0f};
-    const uint8_t k = coeffs.size();
+    size_t k_value = 0;
+    if (!(input >> k_value)) {
+        throw std::runtime_error("Kernel file is missing the kernel length prefix: " + path);
+    }
 
-    std::cout << "Halo:";
-    print_tile(halo, 32, 32);
-    std::cout << "\n";
-    std::cout << "Input:";
-    print_tile(input, 32, 32);
-    std::cout << "\n";
+    if (k_value < 2 || k_value > 13) {
+        throw std::runtime_error("Kernel length must be in the range [2, 13], got: " + std::to_string(k_value));
+    }
 
-    const std::vector<uint32_t> tile_shape = {1, 1, tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH};
+    std::vector<float> coeffs;
+    coeffs.reserve(k_value);
 
-    // User-requested debug layout: keep first-row-contiguous row-major tile payload.
-    // This bypasses host tilize so flattened tile content matches the custom 32x32 printout.
-    auto tiled_halo = tilize_nfaces(halo, 32, 32);
-    auto tiled_input = tilize_nfaces(input, 32, 32);
+    float coeff = 0.0f;
+    while (input >> coeff) {
+        coeffs.push_back(coeff);
+    }
 
-    std::vector<float> combined((tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH) * 2);
+    if (!input.eof() && input.fail()) {
+        throw std::runtime_error("Failed while reading kernel coefficients from: " + path);
+    }
 
-    std::copy(tiled_halo.begin(), tiled_halo.end(), combined.begin());
-    std::copy(
-        tiled_input.begin(),
-        tiled_input.end(),
-        combined.begin() + tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH);
-    tt::tt_metal::distributed::EnqueueWriteMeshBuffer(command_queue, input_dram_buffer, combined, false);
+    if (coeffs.size() != k_value) {
+        throw std::runtime_error(
+            "Kernel file coefficient count mismatch: expected " + std::to_string(k_value) + " but got " +
+            std::to_string(coeffs.size()));
+    }
 
-    constexpr tt::CBIndex halo_cb = tt::CBIndex::c_0;
-    constexpr tt::CBIndex input_cb = tt::CBIndex::c_1;
-    constexpr tt::CBIndex output_cb = tt::CBIndex::c_16;
+    return KernelSpec{static_cast<uint8_t>(k_value), std::move(coeffs)};
+}
 
-    create_circular_buffer(program, core, halo_cb, 1, size_tile_b, cb_data_format);
-    create_circular_buffer(program, core, input_cb, 1, size_tile_b, cb_data_format);
-    create_circular_buffer(program, core, output_cb, 1, size_tile_b, cb_data_format);
+std::vector<float> split_tile(const std::vector<float>& values, size_t row_begin, size_t rows, size_t cols) {
+    std::vector<float> tile;
+    tile.reserve(rows * cols);
 
-    std::vector<uint32_t> reader_compile_args;
-    std::vector<uint32_t> writer_compile_args;
-    reader_compile_args.push_back(static_cast<uint32_t>(halo_cb));
-    reader_compile_args.push_back(static_cast<uint32_t>(input_cb));
-    writer_compile_args.push_back(static_cast<uint32_t>(output_cb));
-    std::vector<uint32_t> compute_compile_args;
-    compute_compile_args.push_back(static_cast<uint32_t>(k));
-    compute_compile_args.push_back(static_cast<uint32_t>(halo_cb));
-    compute_compile_args.push_back(static_cast<uint32_t>(input_cb));
-    compute_compile_args.push_back(static_cast<uint32_t>(output_cb));
+    for (size_t row = 0; row < rows; ++row) {
+        const size_t offset = (row_begin + row) * cols;
+        tile.insert(tile.end(), values.begin() + offset, values.begin() + offset + cols);
+    }
 
-    push_step_coeffs_to_compile_args(compute_compile_args, coeffs);
+    return tile;
+}
 
-    tt::tt_metal::TensorAccessorArgs(input_dram_buffer->get_backing_buffer()).append_to(reader_compile_args);
-    tt::tt_metal::TensorAccessorArgs(output_dram_buffer->get_backing_buffer()).append_to(writer_compile_args);
-    auto reader_ker = tt::tt_metal::CreateKernel(
-        program,
-        reader,
-        core,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = tt::tt_metal::RISCV_0_default,
-            .compile_args = reader_compile_args,
-        });
+void print_matrix_row_major(const std::vector<float>& values, size_t rows, size_t cols) {
+    std::cout << std::setprecision(std::numeric_limits<float>::max_digits10);
+    for (size_t row = 0; row < rows; ++row) {
+        for (size_t col = 0; col < cols; ++col) {
+            if (col > 0) {
+                std::cout << ' ';
+            }
+            std::cout << values[row * cols + col];
+        }
+        std::cout << '\n';
+    }
+}
 
-    auto wtiter_ker = tt::tt_metal::CreateKernel(
-        program,
-        writer,
-        core,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-            .noc = tt::tt_metal::RISCV_1_default,
-            .compile_args = writer_compile_args,
-        });
+int main(int argc, char** argv) {
+    try {
+        constexpr uint32_t num_tiles_input{2};
+        constexpr uint32_t num_tiles_output{1};
+        constexpr tt::DataFormat cb_data_format = tt::DataFormat::Float32;
+        const uint32_t size_tile_b = tt::tile_size(cb_data_format);
+        constexpr int device_id{0};
+        std::string reader{"tt-wavelet/kernels/dataflow/stencil_read.cpp"};
+        std::string writer{"tt-wavelet/kernels/dataflow/stencil_write.cpp"};
+        std::string compute{"tt-wavelet/kernels/stencil_compute.cpp"};
+        auto mesh_device = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
 
-    auto compute_ker = tt::tt_metal::CreateKernel(
-        program,
-        compute,
-        core,
-        tt::tt_metal::ComputeConfig{
-            .math_fidelity = MathFidelity::HiFi4, .fp32_dest_acc_en = true, .compile_args = compute_compile_args});
+        tt::tt_metal::distributed::MeshCommandQueue& command_queue = mesh_device->mesh_command_queue();
+        auto program = tt::tt_metal::CreateProgram();
 
-    tt::tt_metal::SetRuntimeArgs(program, reader_ker, core, {static_cast<uint32_t>(input_dram_buffer->address())});
+        constexpr tt::tt_metal::CoreCoord core{0, 0};
 
-    tt::tt_metal::SetRuntimeArgs(program, wtiter_ker, core, {static_cast<uint32_t>(output_dram_buffer->address())});
-    tt::tt_metal::distributed::MeshWorkload workload;
-    tt::tt_metal::distributed::MeshCoordinateRange device_range =
-        tt::tt_metal::distributed::MeshCoordinateRange(mesh_device->shape());
-    workload.add_program(device_range, std::move(program));
-    tt::tt_metal::distributed::EnqueueMeshWorkload(command_queue, workload, false);
-    tt::tt_metal::distributed::Finish(command_queue);
+        tt::tt_metal::distributed::DeviceLocalBufferConfig buffer_config{
+            .page_size = size_tile_b, .buffer_type = tt::tt_metal::BufferType::DRAM};
 
-    std::vector<float> result_of_stencil;
-    tt::tt_metal::distributed::EnqueueReadMeshBuffer(command_queue, result_of_stencil, output_dram_buffer);
-    std::cout << "Result of stencil computation:" << std::endl;
-    std::vector<float> result_row_major = untilize_nfaces(result_of_stencil, 32, 32);
-    print_tile(result_row_major, 32, 32);
+        tt::tt_metal::distributed::ReplicatedBufferConfig input_dram_config{
+            .size = static_cast<uint64_t>(size_tile_b * num_tiles_input)};
+        tt::tt_metal::distributed::ReplicatedBufferConfig output_dram_config{
+            .size = static_cast<uint64_t>(size_tile_b * num_tiles_output)};
 
-    //     std::vector<float> debug_tiles;
-    // tt::tt_metal::distributed::EnqueueReadMeshBuffer(command_queue, debug_tiles, output_dram_buffer);
+        auto input_dram_buffer =
+            tt::tt_metal::distributed::MeshBuffer::create(input_dram_config, buffer_config, mesh_device.get());
+        auto output_dram_buffer =
+            tt::tt_metal::distributed::MeshBuffer::create(output_dram_config, buffer_config, mesh_device.get());
 
-    // std::vector<float> result_of_halo(debug_tiles.begin(), debug_tiles.begin() + elems_per_tile);
-    // std::vector<float> result_of_input(debug_tiles.begin() + elems_per_tile, debug_tiles.end());
+        std::vector<float> halo;
+        std::vector<float> input;
+        std::vector<float> coeffs;
+        uint8_t k = 0;
 
-    // print_array(result_of_halo);
-    // print_array(result_of_input);
+        if (argc == 3) {
+            const std::string tensor_path = argv[1];
+            const std::string kernel_path = argv[2];
 
-    // auto result_row_halo = convert_layout(
-    //     tt::stl::make_const_span(result_of_halo),
-    //     tile_shape,
-    //     TensorLayoutType::TILED_NFACES,
-    //     TensorLayoutType::LIN_ROW_MAJOR);
+            const std::vector<float> tensor_values = read_floats_from_file(tensor_path);
+            if (tensor_values.size() != 64 * 32) {
+                throw std::runtime_error(
+                    "Input tensor must contain exactly 64x32 = 2048 floats, got " +
+                    std::to_string(tensor_values.size()));
+            }
 
-    // print_prefix(result_row_halo, 64, "row-major prefix:");
+            const KernelSpec kernel_spec = read_kernel_from_file(kernel_path);
+            k = kernel_spec.k;
+            coeffs = kernel_spec.coeffs;
 
-    // auto result_row_input = convert_layout(
-    //     tt::stl::make_const_span(result_of_input),
-    //     tile_shape,
-    //     TensorLayoutType::TILED_NFACES,
-    //     TensorLayoutType::LIN_ROW_MAJOR);
+            halo = split_tile(tensor_values, 0, 32, 32);
+            input = split_tile(tensor_values, 32, 32, 32);
+        } else if (argc == 1) {
+            halo.assign(32 * 32, 1.0f);
+            input.assign(32 * 32, 2.0f);
+            coeffs = {1.0f, 1.0f, 1.0f};
+            k = static_cast<uint8_t>(coeffs.size());
+        } else {
+            throw std::runtime_error(
+                "Usage: tt_wavelet_test <input_tensor_file> <kernel_file>\n"
+                "Both files should contain whitespace-separated floats; the kernel file must begin with K.");
+        }
 
-    // print_prefix(result_row_input, 64, "row-major prefix:");
+        // User-requested debug layout: keep first-row-contiguous row-major tile payload.
+        // This bypasses host tilize so flattened tile content matches the custom 32x32 printout.
+        auto tiled_halo = tilize_nfaces(halo, 32, 32);
+        auto tiled_input = tilize_nfaces(input, 32, 32);
+
+        std::vector<float> combined((tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH) * 2);
+
+        std::copy(tiled_halo.begin(), tiled_halo.end(), combined.begin());
+        std::copy(
+            tiled_input.begin(),
+            tiled_input.end(),
+            combined.begin() + tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH);
+        tt::tt_metal::distributed::EnqueueWriteMeshBuffer(command_queue, input_dram_buffer, combined, false);
+
+        constexpr tt::CBIndex halo_cb = tt::CBIndex::c_0;
+        constexpr tt::CBIndex input_cb = tt::CBIndex::c_1;
+        constexpr tt::CBIndex output_cb = tt::CBIndex::c_16;
+
+        create_circular_buffer(program, core, halo_cb, 1, size_tile_b, cb_data_format);
+        create_circular_buffer(program, core, input_cb, 1, size_tile_b, cb_data_format);
+        create_circular_buffer(program, core, output_cb, 1, size_tile_b, cb_data_format);
+
+        std::vector<uint32_t> reader_compile_args;
+        std::vector<uint32_t> writer_compile_args;
+        reader_compile_args.push_back(static_cast<uint32_t>(halo_cb));
+        reader_compile_args.push_back(static_cast<uint32_t>(input_cb));
+        writer_compile_args.push_back(static_cast<uint32_t>(output_cb));
+        std::vector<uint32_t> compute_compile_args;
+        compute_compile_args.push_back(static_cast<uint32_t>(k));
+        compute_compile_args.push_back(static_cast<uint32_t>(halo_cb));
+        compute_compile_args.push_back(static_cast<uint32_t>(input_cb));
+        compute_compile_args.push_back(static_cast<uint32_t>(output_cb));
+
+        push_step_coeffs_to_compile_args(compute_compile_args, coeffs);
+
+        tt::tt_metal::TensorAccessorArgs(input_dram_buffer->get_backing_buffer()).append_to(reader_compile_args);
+        tt::tt_metal::TensorAccessorArgs(output_dram_buffer->get_backing_buffer()).append_to(writer_compile_args);
+        auto reader_ker = tt::tt_metal::CreateKernel(
+            program,
+            reader,
+            core,
+            tt::tt_metal::DataMovementConfig{
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt::tt_metal::RISCV_0_default,
+                .compile_args = reader_compile_args,
+            });
+
+        auto wtiter_ker = tt::tt_metal::CreateKernel(
+            program,
+            writer,
+            core,
+            tt::tt_metal::DataMovementConfig{
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = tt::tt_metal::RISCV_1_default,
+                .compile_args = writer_compile_args,
+            });
+
+        auto compute_ker = tt::tt_metal::CreateKernel(
+            program,
+            compute,
+            core,
+            tt::tt_metal::ComputeConfig{
+                .math_fidelity = MathFidelity::HiFi4,
+                .fp32_dest_acc_en = true,
+                .compile_args = compute_compile_args});
+
+        tt::tt_metal::SetRuntimeArgs(program, reader_ker, core, {static_cast<uint32_t>(input_dram_buffer->address())});
+
+        tt::tt_metal::SetRuntimeArgs(program, wtiter_ker, core, {static_cast<uint32_t>(output_dram_buffer->address())});
+        tt::tt_metal::distributed::MeshWorkload workload;
+        tt::tt_metal::distributed::MeshCoordinateRange device_range =
+            tt::tt_metal::distributed::MeshCoordinateRange(mesh_device->shape());
+        workload.add_program(device_range, std::move(program));
+        tt::tt_metal::distributed::EnqueueMeshWorkload(command_queue, workload, false);
+        tt::tt_metal::distributed::Finish(command_queue);
+
+        std::vector<float> result_of_stencil;
+        tt::tt_metal::distributed::EnqueueReadMeshBuffer(command_queue, result_of_stencil, output_dram_buffer);
+        std::vector<float> result_row_major = untilize_nfaces(result_of_stencil, 32, 32);
+        print_matrix_row_major(result_row_major, 32, 32);
+
+        //     std::vector<float> debug_tiles;
+        // tt::tt_metal::distributed::EnqueueReadMeshBuffer(command_queue, debug_tiles, output_dram_buffer);
+
+        // std::vector<float> result_of_halo(debug_tiles.begin(), debug_tiles.begin() + elems_per_tile);
+        // std::vector<float> result_of_input(debug_tiles.begin() + elems_per_tile, debug_tiles.end());
+
+        // print_array(result_of_halo);
+        // print_array(result_of_input);
+
+        // auto result_row_halo = convert_layout(
+        //     tt::stl::make_const_span(result_of_halo),
+        //     tile_shape,
+        //     TensorLayoutType::TILED_NFACES,
+        //     TensorLayoutType::LIN_ROW_MAJOR);
+
+        // print_prefix(result_row_halo, 64, "row-major prefix:");
+
+        // auto result_row_input = convert_layout(
+        //     tt::stl::make_const_span(result_of_input),
+        //     tile_shape,
+        //     TensorLayoutType::TILED_NFACES,
+        //     TensorLayoutType::LIN_ROW_MAJOR);
+
+        // print_prefix(result_row_input, 64, "row-major prefix:");
+
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "Error: " << error.what() << std::endl;
+        return 1;
+    }
 }

--- a/tt-wavelet/stencil.cpp
+++ b/tt-wavelet/stencil.cpp
@@ -11,8 +11,6 @@
 #include "tt-metalium/mesh_device.hpp"
 #include "tt-metalium/tensor_accessor_args.hpp"
 #include "tt-metalium/tilize_utils.hpp"
-#include "tt_wavelet/include/pad_split.hpp"
-#include "tt_wavelet/include/pad_split_device.hpp"
 
 inline tt::tt_metal::CBHandle create_circular_buffer(
     tt::tt_metal::Program& program,
@@ -37,6 +35,23 @@ void print_array(const std::vector<T>& arr) {
     std::cout << "]" << std::endl;
 }
 
+template <typename T>
+void print_tile(const std::vector<T>& arr, const size_t rows = 32, const size_t cols = 32) {
+    std::cout << "[";
+    for (size_t i = 0; i < rows; ++i) {
+        if(i > 0) {
+            std::cout << std::endl << " ";
+        }
+
+        for (size_t j = 0; j < cols; ++j) {
+            if(j > 0) {
+                std::cout << ", ";
+            }
+            std::cout << arr[i * cols + j];
+        }
+    }
+    std::cout << "]" << std::endl;
+}
 
 void push_step_coeffs_to_compile_args(std::vector<uint32_t>& args, std::vector<float>& coeffs) {
     for (size_t i{0}; i < coeffs.size(); ++i) {
@@ -74,55 +89,32 @@ int main() {
     auto output_dram_buffer =
         tt::tt_metal::distributed::MeshBuffer::create(output_dram_config, buffer_config, mesh_device.get());
 
-    std::vector<float> halo(32, 0.0f);
-    std::vector<float> input(32, 0.0f);
+    std::vector<float> halo(32 * 32, 1.0f);
+    std::vector<float> input(32 * 32, 2.0f);
     std::vector<float> coeffs = {1.0f, 1.0f, 1.0f};
     const uint8_t k = coeffs.size();
-    const uint8_t halo_idx = halo_pad(k);
-
-    size_t sig = 1;
-    const size_t halo_signal_count = halo.size() - halo_idx;
-    for (size_t j = 0; j < halo_signal_count; ++j) {
-        halo[halo_idx + j] = static_cast<float>(sig++);
-    }
-
-    const size_t input_signal_count = std::min(input.size(), static_cast<size_t>(halo_idx));
-    for (size_t j = 0; j < input_signal_count; ++j) {
-        input[j] = static_cast<float>(sig++);
-    }
 
     std::cout << "Halo:";
-    print_array(halo);
+    print_tile(halo, 32, 32);
     std::cout << "\n";
     std::cout << "Input:";
-    print_array(input);
+    print_tile(input, 32, 32);
     std::cout << "\n";
-
-    std::vector<float> halo_tile(elems_per_tile, 0.0f);
-    std::vector<float> input_tile(elems_per_tile, 0.0f);
-    std::copy(halo.begin(), halo.end(), halo_tile.begin());
-    std::copy(input.begin(), input.end(), input_tile.begin());
 
     const std::vector<uint32_t> tile_shape = {1, 1, tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH};
 
     // User-requested debug layout: keep first-row-contiguous row-major tile payload.
     // This bypasses host tilize so flattened tile content matches the custom 32x32 printout.
-    auto tiled_halo = halo_tile;
-    auto tiled_input = input_tile;
+    auto tiled_halo = tilize_nfaces(halo, 32, 32);
+    auto tiled_input = tilize_nfaces(input, 32, 32);
 
     std::vector<float> combined((tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH) * 2);
-    std::cout << "Tiled Halo:" << std::endl;
-    print_array(tiled_halo);
-    std::cout << "Tiled Input:" << std::endl;
-    print_array(tiled_input);
 
     std::copy(tiled_halo.begin(), tiled_halo.end(), combined.begin());
     std::copy(
         tiled_input.begin(),
         tiled_input.end(),
         combined.begin() + tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH);
-    std::cout << "Combined Tiles (halo followed by input):" << std::endl;
-    print_array(combined);
     tt::tt_metal::distributed::EnqueueWriteMeshBuffer(command_queue, input_dram_buffer, combined, false);
 
     constexpr tt::CBIndex halo_cb = tt::CBIndex::c_0;
@@ -188,7 +180,8 @@ int main() {
     std::vector<float> result_of_stencil;
     tt::tt_metal::distributed::EnqueueReadMeshBuffer(command_queue, result_of_stencil, output_dram_buffer);
     std::cout << "Result of stencil computation:" << std::endl;
-    print_array(result_of_stencil);
+    std::vector<float> result_row_major = untilize_nfaces(result_of_stencil, 32, 32);
+    print_tile(result_row_major, 32, 32);
 
     //     std::vector<float> debug_tiles;
     // tt::tt_metal::distributed::EnqueueReadMeshBuffer(command_queue, debug_tiles, output_dram_buffer);

--- a/tt-wavelet/stencil.cpp
+++ b/tt-wavelet/stencil.cpp
@@ -247,6 +247,10 @@ int main(int argc, char** argv) {
 
         push_step_coeffs_to_compile_args(compute_compile_args, coeffs);
 
+        std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+        unpack_to_dest_mode[kLwtSrcTile0Cb] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[kLwtSrcTile1Cb] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[kLwtBaseTileCb] = UnpackToDestMode::UnpackToDestFp32;
         tt::tt_metal::TensorAccessorArgs(input_dram_buffer->get_backing_buffer()).append_to(reader_compile_args);
         tt::tt_metal::TensorAccessorArgs(output_dram_buffer->get_backing_buffer()).append_to(writer_compile_args);
         auto reader_ker = tt::tt_metal::CreateKernel(
@@ -276,6 +280,7 @@ int main(int argc, char** argv) {
             tt::tt_metal::ComputeConfig{
                 .math_fidelity = MathFidelity::HiFi4,
                 .fp32_dest_acc_en = true,
+                .unpack_to_dest_mode = unpack_to_dest_mode,
                 .compile_args = compute_compile_args});
 
         tt::tt_metal::SetRuntimeArgs(program, reader_ker, core, {static_cast<uint32_t>(input_dram_buffer->address())});

--- a/tt-wavelet/stencil.cpp
+++ b/tt-wavelet/stencil.cpp
@@ -248,9 +248,9 @@ int main(int argc, char** argv) {
         push_step_coeffs_to_compile_args(compute_compile_args, coeffs);
 
         std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-        unpack_to_dest_mode[kLwtSrcTile0Cb] = UnpackToDestMode::UnpackToDestFp32;
-        unpack_to_dest_mode[kLwtSrcTile1Cb] = UnpackToDestMode::UnpackToDestFp32;
-        unpack_to_dest_mode[kLwtBaseTileCb] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[halo_cb] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[input_cb] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[output_cb] = UnpackToDestMode::UnpackToDestFp32;
         tt::tt_metal::TensorAccessorArgs(input_dram_buffer->get_backing_buffer()).append_to(reader_compile_args);
         tt::tt_metal::TensorAccessorArgs(output_dram_buffer->get_backing_buffer()).append_to(writer_compile_args);
         auto reader_ker = tt::tt_metal::CreateKernel(

--- a/validate_stencil.py
+++ b/validate_stencil.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+DEFAULT_EXE_CANDIDATES = (
+    PROJECT_ROOT / "build" / "tt-wavelet" / "tt_wavelet_test",
+    PROJECT_ROOT / "build" / "tt_wavelet_test",
+    PROJECT_ROOT / "build" / "tt-wavelet_test",
+)
+
+
+@dataclass(frozen=True)
+class CaseSpec:
+    name: str
+    input_tensor: np.ndarray
+    kernel: np.ndarray
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the TT-wavelet vertical stencil against generated cases and validate the output."
+    )
+    parser.add_argument(
+        "--exe",
+        type=Path,
+        default=None,
+        help="Path to the stencil executable. If omitted, a few common build locations are tried.",
+    )
+    parser.add_argument(
+        "--tolerance",
+        type=float,
+        default=1e-5,
+        help="Absolute and relative tolerance for validation (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--random-seed",
+        type=int,
+        default=1234,
+        help="Seed used for deterministic random test generation (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--extra-random-cases",
+        type=int,
+        default=0,
+        help="Additional random cases per kernel size beyond the built-in structured cases.",
+    )
+    parser.add_argument(
+        "--keep-failures",
+        action="store_true",
+        help="Keep per-case temporary files when a validation failure occurs.",
+    )
+    return parser.parse_args()
+
+
+def resolve_executable(explicit: Path | None) -> Path:
+    if explicit is not None:
+        if not explicit.exists():
+            raise FileNotFoundError(f"Executable not found: {explicit}")
+        return explicit
+
+    env_value = os.environ.get("TT_WAVELET_STENCIL_EXE")
+    if env_value:
+        candidate = Path(env_value)
+        if candidate.exists():
+            return candidate
+        raise FileNotFoundError(f"TT_WAVELET_STENCIL_EXE points to a missing executable: {candidate}")
+
+    for candidate in DEFAULT_EXE_CANDIDATES:
+        if candidate.exists():
+            return candidate
+
+    tried = "\n".join(f"  - {candidate}" for candidate in DEFAULT_EXE_CANDIDATES)
+    raise FileNotFoundError(
+        "Could not find the stencil executable. Tried:\n"
+        f"{tried}\n"
+        "You can pass --exe or set TT_WAVELET_STENCIL_EXE."
+    )
+
+
+def make_random_tensor(rng: np.random.Generator) -> np.ndarray:
+    return rng.normal(loc=0.0, scale=1.0, size=(64, 32)).astype(np.float32)
+
+
+def make_ramp_tensor() -> np.ndarray:
+    rows = np.linspace(-1.0, 1.0, num=64, dtype=np.float32)[:, None]
+    cols = np.linspace(-0.5, 0.5, num=32, dtype=np.float32)[None, :]
+    return (rows + cols).astype(np.float32)
+
+
+def make_impulse_tensor() -> np.ndarray:
+    tensor = np.zeros((64, 32), dtype=np.float32)
+    tensor[16, 7] = 2.5
+    tensor[31, 15] = -1.75
+    tensor[48, 23] = 3.0
+    tensor[63, 31] = -0.5
+    return tensor
+
+
+def make_checkerboard_tensor() -> np.ndarray:
+    rows = np.arange(64, dtype=np.float32)[:, None]
+    cols = np.arange(32, dtype=np.float32)[None, :]
+    return np.where(((rows + cols) % 2) == 0, 1.0, -1.0).astype(np.float32)
+
+
+def make_random_kernel(k: int, rng: np.random.Generator) -> np.ndarray:
+    kernel = rng.uniform(-1.0, 1.0, size=k).astype(np.float32)
+    if np.allclose(kernel, 0.0):
+        kernel[0] = 1.0
+    return kernel
+
+
+def make_ramp_kernel(k: int) -> np.ndarray:
+    return np.linspace(-1.0, 1.0, num=k, dtype=np.float32)
+
+
+def make_alternating_kernel(k: int) -> np.ndarray:
+    values = np.array([(-1.0 if (i % 2) else 1.0) * (i + 1) for i in range(k)], dtype=np.float32)
+    return values / float(k)
+
+
+def make_gaussian_kernel(k: int) -> np.ndarray:
+    positions = np.arange(k, dtype=np.float32) - (k - 1) / 2.0
+    sigma = max(1.0, k / 3.0)
+    kernel = np.exp(-0.5 * (positions / sigma) ** 2).astype(np.float32)
+    kernel /= np.sum(kernel, dtype=np.float32)
+    return kernel
+
+
+def build_cases_for_k(k: int, rng: np.random.Generator, extra_random_cases: int) -> list[CaseSpec]:
+    cases = [
+        CaseSpec(name="random/random", input_tensor=make_random_tensor(rng), kernel=make_random_kernel(k, rng)),
+        CaseSpec(name="ramp/alternating", input_tensor=make_ramp_tensor(), kernel=make_alternating_kernel(k)),
+        CaseSpec(name="impulse/gaussian", input_tensor=make_impulse_tensor(), kernel=make_gaussian_kernel(k)),
+        CaseSpec(name="checkerboard/ramp", input_tensor=make_checkerboard_tensor(), kernel=make_ramp_kernel(k)),
+    ]
+
+    for index in range(extra_random_cases):
+        cases.append(
+            CaseSpec(
+                name=f"random_extra_{index + 1}",
+                input_tensor=make_random_tensor(rng),
+                kernel=make_random_kernel(k, rng),
+            )
+        )
+
+    return cases
+
+
+def write_input_tensor(path: Path, tensor: np.ndarray) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        for row in tensor:
+            handle.write(" ".join(f"{float(value):.9g}" for value in row))
+            handle.write("\n")
+
+
+def write_kernel(path: Path, kernel: np.ndarray) -> None:
+    coeffs = " ".join(f"{float(value):.9g}" for value in kernel)
+    path.write_text(f"{kernel.size} {coeffs}\n", encoding="utf-8")
+
+
+def run_executable(exe: Path, tensor_path: Path, kernel_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(exe), str(tensor_path), str(kernel_path)],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def parse_output_matrix(stdout: str) -> np.ndarray:
+    rows: list[list[float]] = []
+    for raw_line in stdout.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        parts = line.split()
+        if len(parts) != 32:
+            continue
+        try:
+            row = [float(value) for value in parts]
+        except ValueError:
+            continue
+        rows.append(row)
+
+    if len(rows) < 32:
+        raise ValueError(
+            f"Could not parse a 32x32 output matrix from stdout. Parsed {len(rows)} candidate rows.\n"
+            f"Captured stdout:\n{stdout}"
+        )
+
+    return np.array(rows[-32:], dtype=np.float32)
+
+
+def reference_valid_convolution(tensor: np.ndarray, kernel: np.ndarray) -> np.ndarray:
+    expected = np.zeros((32, 32), dtype=np.float32)
+    for col in range(32):
+        column = tensor[:, col].astype(np.float32, copy=False)
+        valid = np.convolve(column, kernel.astype(np.float32, copy=False), mode="valid")
+        expected[:, col] = valid[:32].astype(np.float32, copy=False)
+    return expected
+
+
+def compare_matrices(actual: np.ndarray, expected: np.ndarray, tolerance: float) -> tuple[bool, float, tuple[int, int], float, float]:
+    diff = actual.astype(np.float32) - expected.astype(np.float32)
+    abs_diff = np.abs(diff)
+    max_index = np.unravel_index(int(np.argmax(abs_diff)), abs_diff.shape)
+    max_abs = float(abs_diff[max_index])
+    actual_value = float(actual[max_index])
+    expected_value = float(expected[max_index])
+    ok = np.allclose(actual, expected, rtol=tolerance, atol=tolerance)
+    return ok, max_abs, max_index, actual_value, expected_value
+
+
+def format_case_header(k: int, case: str) -> str:
+    return f"K={k:02d} case={case}"
+
+
+def save_failure_artifact(
+    k: int,
+    case_name: str,
+    tensor: np.ndarray,
+    kernel: np.ndarray,
+    stdout: str,
+    stderr: str,
+) -> Path:
+    safe_case = case_name.replace("/", "_").replace(" ", "_")
+    artifact_dir = PROJECT_ROOT / "validation_failures" / f"k{k:02d}_{safe_case}"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    write_input_tensor(artifact_dir / "input_tensor.txt", tensor)
+    write_kernel(artifact_dir / "kernel.txt", kernel)
+    (artifact_dir / "stdout.txt").write_text(stdout, encoding="utf-8")
+    (artifact_dir / "stderr.txt").write_text(stderr, encoding="utf-8")
+    return artifact_dir
+
+
+def main() -> int:
+    args = parse_args()
+    exe = resolve_executable(args.exe)
+    rng = np.random.default_rng(args.random_seed)
+
+    total = 0
+    failures: list[str] = []
+
+    for k in range(2, 14):
+        cases = build_cases_for_k(k, rng, args.extra_random_cases)
+        for case in cases:
+            total += 1
+            with tempfile.TemporaryDirectory(prefix=f"stencil_k{k:02d}_") as tmp_dir:
+                tmp_path = Path(tmp_dir)
+                tensor_path = tmp_path / "input_tensor.txt"
+                kernel_path = tmp_path / "kernel.txt"
+
+                write_input_tensor(tensor_path, case.input_tensor)
+                write_kernel(kernel_path, case.kernel)
+
+                completed = run_executable(exe, tensor_path, kernel_path)
+                if completed.returncode != 0:
+                    message = (
+                        f"{format_case_header(k, case.name)} failed to execute with exit code {completed.returncode}.\n"
+                        f"stdout:\n{completed.stdout}\n"
+                        f"stderr:\n{completed.stderr}"
+                    )
+                    if args.keep_failures:
+                        artifact_dir = save_failure_artifact(
+                            k, case.name, case.input_tensor, case.kernel, completed.stdout, completed.stderr
+                        )
+                        message += f"\nSaved failure artifacts to: {artifact_dir}"
+                    failures.append(message)
+                    print(message)
+                    continue
+
+                try:
+                    actual = parse_output_matrix(completed.stdout)
+                except ValueError as exc:
+                    message = f"{format_case_header(k, case.name)} parse failure: {exc}"
+                    if args.keep_failures:
+                        artifact_dir = save_failure_artifact(
+                            k, case.name, case.input_tensor, case.kernel, completed.stdout, completed.stderr
+                        )
+                        message += f"\nSaved failure artifacts to: {artifact_dir}"
+                    failures.append(message)
+                    print(failures[-1])
+                    continue
+
+                expected = reference_valid_convolution(case.input_tensor, case.kernel)
+                ok, max_abs, max_index, actual_value, expected_value = compare_matrices(
+                    actual, expected, args.tolerance
+                )
+
+                if ok:
+                    print(f"PASS {format_case_header(k, case.name)} max_abs={max_abs:.3e}")
+                else:
+                    message = (
+                        f"FAIL {format_case_header(k, case.name)} max_abs={max_abs:.3e} at row={max_index[0]} col={max_index[1]} "
+                        f"actual={actual_value:.9g} expected={expected_value:.9g}"
+                    )
+                    if args.keep_failures:
+                        artifact_dir = save_failure_artifact(
+                            k, case.name, case.input_tensor, case.kernel, completed.stdout, completed.stderr
+                        )
+                        message += f"\nSaved failure artifacts to: {artifact_dir}"
+                    failures.append(message)
+                    print(message)
+
+    print()
+    print(f"Completed {total} cases: {total - len(failures)} passed, {len(failures)} failed.")
+    if failures:
+        print("\nFailures:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This pull request introduces a new vertical stencil compute pipeline for the `tt-wavelet` project, including new dataflow and compute kernels, and refactors the SFPI vertical stencil implementation for improved flexibility and clarity. The main changes are grouped below:

**New Pipeline and Kernels:**

* Added new dataflow kernel `stencil_read.cpp` to read halo and input tiles from DRAM to circular buffers, and `stencil_write.cpp` to write output tiles from circular buffers to DRAM. [[1]](diffhunk://#diff-d833c90a769b063709c963c50ff5d9e300e07d16608fc8cfc38d18093a9d8486R1-R28) [[2]](diffhunk://#diff-84d9cd11227a7740b8d86d00c634d9c420fa8ad1f47d1471794d173634861072R1-R27)
* Introduced a new compute kernel `stencil_compute.cpp` that initializes the SFPU, loads input tiles, applies the vertical stencil operation, and writes the results to the output buffer.

**SFPI Vertical Stencil Refactor:**

* Refactored `vertical_stencil_sfpi.h` to generalize the block and tile processing, improve address calculation, and support variable stencil sizes (`K`). The interface is now more flexible, and the implementation is clearer and more robust. [[1]](diffhunk://#diff-28e6298e66a6d1ed04b2cb0ddb002e098bfe407a4cdf373ab55ee822ef3ad9dcL25-R66) [[2]](diffhunk://#diff-28e6298e66a6d1ed04b2cb0ddb002e098bfe407a4cdf373ab55ee822ef3ad9dcL58-R102) [[3]](diffhunk://#diff-28e6298e66a6d1ed04b2cb0ddb002e098bfe407a4cdf373ab55ee822ef3ad9dcL88-R162) [[4]](diffhunk://#diff-28e6298e66a6d1ed04b2cb0ddb002e098bfe407a4cdf373ab55ee822ef3ad9dcL153-R201) [[5]](diffhunk://#diff-28e6298e66a6d1ed04b2cb0ddb002e098bfe407a4cdf373ab55ee822ef3ad9dcL182-R215)

**Build System Updates:**

* Updated `tt-wavelet/CMakeLists.txt` to add a new test executable `tt_wavelet_test` (replacing the previous `lwt` target), remove Python-based code generation, and adjust include directory handling. [[1]](diffhunk://#diff-24b7c5e2e54136f87e344dc7823c522fac413fcc3b24314c2c519cb1297102d0L2-R6) [[2]](diffhunk://#diff-24b7c5e2e54136f87e344dc7823c522fac413fcc3b24314c2c519cb1297102d0L37-L39) [[3]](diffhunk://#diff-24b7c5e2e54136f87e344dc7823c522fac413fcc3b24314c2c519cb1297102d0L48-R40)
* Added a new top-level build script `qbuild.sh` to streamline building and installing the project, with support for specifying build type and parallel jobs.